### PR TITLE
feat: 코인 구매 (PortOne 결제)

### DIFF
--- a/src/main/java/com/picktartup/coinservice/common/config/WebConfig.java
+++ b/src/main/java/com/picktartup/coinservice/common/config/WebConfig.java
@@ -1,0 +1,25 @@
+package com.picktartup.coinservice.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig {
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**").allowedOrigins("http://localhost:3000");
+            }
+        };
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/picktartup/coinservice/controller/CoinController.java
+++ b/src/main/java/com/picktartup/coinservice/controller/CoinController.java
@@ -36,7 +36,7 @@ public class CoinController {
     // 코인 구매
     @PostMapping("/purchase")
     public ResponseEntity<ApiResponse<CoinPurchaseResponse>> purchaseCoins(@RequestBody CoinPurchaseRequest request) {
-        CoinPurchaseResponse response = coinService.purchaseCoins(request.getWalletId(), request.getAmount());
+        CoinPurchaseResponse response = coinService.purchaseCoins(request.getWalletId(), request.getPaymentId(), request.getAmount());
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 

--- a/src/main/java/com/picktartup/coinservice/dto/CoinPurchaseRequest.java
+++ b/src/main/java/com/picktartup/coinservice/dto/CoinPurchaseRequest.java
@@ -11,5 +11,6 @@ import lombok.Setter;
 @AllArgsConstructor
 public class CoinPurchaseRequest {
     private Long walletId;
+    private String paymentId;
     private double amount;
 }

--- a/src/main/java/com/picktartup/coinservice/dto/PaymentResponse.java
+++ b/src/main/java/com/picktartup/coinservice/dto/PaymentResponse.java
@@ -1,0 +1,2 @@
+package com.picktartup.coinservice.dto;public class PaymentResponse {
+}

--- a/src/main/java/com/picktartup/coinservice/dto/PaymentResponse.java
+++ b/src/main/java/com/picktartup/coinservice/dto/PaymentResponse.java
@@ -1,2 +1,16 @@
-package com.picktartup.coinservice.dto;public class PaymentResponse {
+package com.picktartup.coinservice.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PaymentResponse {
+    private String status;
+    private Amount amount;
+
+    @Getter
+    public static class Amount {
+        private double total;
+    }
 }

--- a/src/main/java/com/picktartup/coinservice/entity/CoinTransaction.java
+++ b/src/main/java/com/picktartup/coinservice/entity/CoinTransaction.java
@@ -26,6 +26,8 @@ public class CoinTransaction {
     private Double coinAmount;
     private LocalDateTime createdAt;
 
+    private String paymentId;
+
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private Users users;

--- a/src/main/java/com/picktartup/coinservice/service/CoinService.java
+++ b/src/main/java/com/picktartup/coinservice/service/CoinService.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Service
 public interface CoinService {
     public Double getBalance(Long walletId);
-    public CoinPurchaseResponse purchaseCoins(Long walletId, double amount);
+    public CoinPurchaseResponse purchaseCoins(Long walletId, String paymentId, double amount);
     public List<CoinTransaction> getPurchases(Long userId);
     public CoinExchangeResponse exchangeCoins(Long walletId, double exchangeAmount);
 }

--- a/src/main/java/com/picktartup/coinservice/service/CoinServiceImpl.java
+++ b/src/main/java/com/picktartup/coinservice/service/CoinServiceImpl.java
@@ -2,6 +2,7 @@ package com.picktartup.coinservice.service;
 
 import com.picktartup.coinservice.dto.CoinExchangeResponse;
 import com.picktartup.coinservice.dto.CoinPurchaseResponse;
+import com.picktartup.coinservice.dto.PaymentResponse;
 import com.picktartup.coinservice.entity.CoinTransaction;
 import com.picktartup.coinservice.entity.TransactionType;
 import com.picktartup.coinservice.entity.Users;
@@ -11,7 +12,13 @@ import com.picktartup.coinservice.repository.UsersRepository;
 import com.picktartup.coinservice.repository.WalletRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,11 +36,35 @@ public class CoinServiceImpl implements CoinService {
     private final WalletRepository walletRepository;
     @Autowired
     private final CoinTransactionRepository coinTransactionRepository;
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Value("${PORTONE_API_SECRET}")
+    private String PORTONE_API_SECRET;
 
     public CoinServiceImpl(UsersRepository usersRepository, WalletRepository walletRepository, CoinTransactionRepository coinTransactionRepository) {
         this.usersRepository = usersRepository;
         this.walletRepository = walletRepository;
         this.coinTransactionRepository = coinTransactionRepository;
+    }
+
+    // PortOne 결제 검증 메서드
+    private boolean validatePayment(String paymentId, double expectedAmount) {
+        String url = "https://api.portone.io/payments/" + paymentId;
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "PortOne " + PORTONE_API_SECRET);
+
+        HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
+        ResponseEntity<PaymentResponse> response = restTemplate.exchange(url, HttpMethod.GET, requestEntity, PaymentResponse.class);
+
+        if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+            throw new RuntimeException("Failed to retrieve payment data");
+        }
+
+        PaymentResponse payment = response.getBody();
+        // 결제 상태가 "PAID"이고 금액이 예상 금액과 일치할 때만 true 반환
+        return "PAID".equals(payment.getStatus()) && payment.getAmount().getTotal() == expectedAmount;
     }
 
     // 잔여 코인 조회
@@ -44,31 +75,39 @@ public class CoinServiceImpl implements CoinService {
 
     // 코인 구매
     @Transactional
-    public CoinPurchaseResponse purchaseCoins(Long walletId, double amount) {
+    public CoinPurchaseResponse purchaseCoins(Long walletId, String paymentId, double amount) {
+        // 사용자 정보 확인
         Users user = usersRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
+        // 사용자 정보 확인
         Optional<Wallet> walletOpt = walletRepository.findById(walletId);
         if (walletOpt.isEmpty()) {
             throw new IllegalArgumentException("지갑을 찾을 수 없습니다.");
         }
         Wallet wallet = walletOpt.get();
 
-        // 코인 구매 로직
+        // 1. PortOne 결제 검증 요청
+        if (!validatePayment(paymentId, amount)) {
+            throw new IllegalArgumentException("결제 검증에 실패했습니다.");
+        }
 
-        // 지갑 잔액 반영
-        wallet.setBalance(wallet.getBalance() + amount);
+        // 2. 결제가 유효하면 코인 구매 처리를 진행
+        wallet.setBalance(wallet.getBalance() + amount); // 지갑 잔액 업데이트
 
-        // CoinTransaction 객체 생성
+        // TODO: 토큰 충전 로직 추가
+
+        // 3. 거래 정보 저장
         CoinTransaction transaction = CoinTransaction.builder()
-                .transactionType(TransactionType.valueOf("PAYMENT"))
+                .transactionType(TransactionType.PAYMENT)
                 .coinAmount(amount)
                 .createdAt(LocalDateTime.now())
                 .users(user)
+                .paymentId(paymentId) // 결제 ID 기록
                 .build();
         coinTransactionRepository.save(transaction);
 
-        // 성공 응답 데이터 생성
+        // 4. 응답 객체 생성 후 반환
         return CoinPurchaseResponse.builder()
                 .transactionId(transaction.getTransactionId())
                 .coinAmount(amount)
@@ -79,7 +118,6 @@ public class CoinServiceImpl implements CoinService {
     // 코인 구매 내역 조회
     public List<CoinTransaction> getPurchases(Long userId) {
         return coinTransactionRepository.findByUsers_UserId(userId);
-
     }
 
     // 코인 현금화


### PR DESCRIPTION
### 👀 관련 이슈
- #2 

### ✨ 작업한 내용
PortOne 결제를 통해 코인을 구매하는 기능을 구현했습니다.
- 클라이언트로부터 받은 결제 검증 요청과 실제로 PortOne에서 이루어진 결제가 동일한지 확인하는 메서드를 추가했습니다.
- 결제 검증이 정상적으로 완료되면 CoinTransaction 객체를 생성해 거래 내역을 기록하며, Wallet의 balance에 반영합니다.


### 🌀 PR Point
CoinTransaction Entity에 paymentId(PortOne 결제 건 ID)가 추가되었습니다.


### 🍰 참고사항
- 현재는 결제 내역을 DB 상에만 반영하였으며, 추후 지갑에 실제로 토큰을 전송하는 로직을 구현할 예정입니다.
- SSL 인증서를 적용할 예정입니다.


### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|PortOne 결제|![image](https://github.com/user-attachments/assets/b554f65f-8de1-484d-a02c-1b4b99186a53)|
