### PR TITLE
✨feat: webclient 통신 시 wallet -> coin 결제 검증 api 추가

### DIFF
--- a/src/main/java/com/picktartup/coinservice/controller/CoinController.java
+++ b/src/main/java/com/picktartup/coinservice/controller/CoinController.java
@@ -1,10 +1,7 @@
 package com.picktartup.coinservice.controller;
 
 import com.picktartup.coinservice.common.dto.ApiResponse;
-import com.picktartup.coinservice.dto.CoinExchangeRequest;
-import com.picktartup.coinservice.dto.CoinExchangeResponse;
-import com.picktartup.coinservice.dto.CoinPurchaseRequest;
-import com.picktartup.coinservice.dto.CoinPurchaseResponse;
+import com.picktartup.coinservice.dto.*;
 import com.picktartup.coinservice.entity.CoinTransaction;
 import com.picktartup.coinservice.service.CoinService;
 import org.springframework.http.ResponseEntity;
@@ -51,6 +48,12 @@ public class CoinController {
     @PostMapping("/exchange")
     public ResponseEntity<ApiResponse<CoinExchangeResponse>> exchangeCoins(@RequestBody CoinExchangeRequest request) {
         CoinExchangeResponse response = coinService.exchangeCoins(request.getWalletId(), request.getExchangeAmount(), request.getExchangeBank(), request.getExchangeAccount());
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @GetMapping("/{transactionId}/validation")
+    public ResponseEntity<ApiResponse<CoinValidationResponse>> validatePayment(@PathVariable Long transactionId) {
+        CoinValidationResponse response = coinService.validatePayment(transactionId);
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 }

--- a/src/main/java/com/picktartup/coinservice/dto/CoinValidationResponse.java
+++ b/src/main/java/com/picktartup/coinservice/dto/CoinValidationResponse.java
@@ -1,0 +1,18 @@
+package com.picktartup.coinservice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CoinValidationResponse {
+    private Long transactionId;
+    private Long userId;
+    private BigDecimal amount;
+}

--- a/src/main/java/com/picktartup/coinservice/repository/CoinTransactionRepository.java
+++ b/src/main/java/com/picktartup/coinservice/repository/CoinTransactionRepository.java
@@ -5,8 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CoinTransactionRepository extends JpaRepository<CoinTransaction, Long> {
     List<CoinTransaction> findByUserId(Long userId);
+    Optional<CoinTransaction> findByTransactionId(Long transactionId);
 }

--- a/src/main/java/com/picktartup/coinservice/service/CoinService.java
+++ b/src/main/java/com/picktartup/coinservice/service/CoinService.java
@@ -2,6 +2,7 @@ package com.picktartup.coinservice.service;
 
 import com.picktartup.coinservice.dto.CoinExchangeResponse;
 import com.picktartup.coinservice.dto.CoinPurchaseResponse;
+import com.picktartup.coinservice.dto.CoinValidationResponse;
 import com.picktartup.coinservice.entity.CoinTransaction;
 import org.springframework.stereotype.Service;
 
@@ -13,4 +14,5 @@ public interface CoinService {
     public CoinPurchaseResponse purchaseCoins(Long walletId, double amount, double coin, String paymentId, String paymentMethod);
     public List<CoinTransaction> getPurchases(Long userId);
     public CoinExchangeResponse exchangeCoins(Long walletId, double exchangeAmount, String exchangeBank, String exchangeAccount);
+    public CoinValidationResponse validatePayment(Long transactionId);
 }

--- a/src/main/java/com/picktartup/coinservice/service/CoinServiceImpl.java
+++ b/src/main/java/com/picktartup/coinservice/service/CoinServiceImpl.java
@@ -2,6 +2,7 @@ package com.picktartup.coinservice.service;
 
 import com.picktartup.coinservice.dto.CoinExchangeResponse;
 import com.picktartup.coinservice.dto.CoinPurchaseResponse;
+import com.picktartup.coinservice.dto.CoinValidationResponse;
 import com.picktartup.coinservice.dto.PaymentResponse;
 import com.picktartup.coinservice.entity.CoinTransaction;
 import com.picktartup.coinservice.entity.TransactionType;
@@ -19,8 +20,10 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Service
@@ -131,6 +134,19 @@ public class CoinServiceImpl implements CoinService {
                 .exchangeAmount(exchangeAmount)
                 .balanceBeforeExchange(balanceBefore)
                 .balanceAfterExchange(walletMock.getBalance())
+                .build();
+    }
+
+    public CoinValidationResponse validatePayment(Long transactionId) {
+        CoinTransaction transaction = coinTransactionRepository.findByTransactionId(transactionId)
+                .orElseThrow(() -> {
+                    return new NoSuchElementException("거래내역을 찾을 수 없습니다.");
+                });
+
+        return CoinValidationResponse.builder()
+                .transactionId(transaction.getTransactionId())
+                .userId(transaction.getUserId())
+                .amount(BigDecimal.valueOf(transaction.getTCoinAmount()))
                 .build();
     }
 }


### PR DESCRIPTION
### 👀 관련 이슈
- #12 

### ✨ 작업한 내용

1. transactionid로 결제검증 로직 API 추가
 - wallet-> coin 으로 결제 ID 에 대한 검증을 위해서  coinservice로 결제 ID(transactionID)가 유효한지 검증합니다.

### 🌀 PR Point
`tpaymentid` 와 `transactionId` 두가지 모두 결제를 한 엔티티에 대한 고유한 값이지만 cointransation의 primary key 인 cointransaction_id 값을 받아서 유효한지 검증하고 wallet 에서 orderid 값이 됩니다.

> 즉, coinservice > cointransaction > transactionId = walletservice > tokentransaction > orderId

### 🍰 참고사항
검증 시 
 - 콜백 온 결제 금액과 결제 ID로 조회된 금액이 동일한지 검증합니다.
 - 콜백을 요청한 userid와 결제를 한 userid가 동일한지 검증합니다.
 
### 📷 스크린샷 또는 GIF
<img width="894" alt="image" src="https://github.com/user-attachments/assets/e17d328c-a384-49b9-8f31-6ecec78aab5b">

