### PR TITLE
✨ feat: AOP 추가 (API 응답 시간, http_method 등등

### DIFF
--- a/src/main/java/com/picktartup/coinservice/aop/CoinLoggingAspect.java
+++ b/src/main/java/com/picktartup/coinservice/aop/CoinLoggingAspect.java
@@ -6,11 +6,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 @Slf4j
 @Aspect
@@ -20,68 +26,95 @@ public class CoinLoggingAspect {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    // 1. 코인 구매 모니터링
+    // 모든 컨트롤러 API 호출 로깅
+    @Around("execution(* com.picktartup.coinservice.controller..*.*(..))")
+    public Object logAllApiCalls(ProceedingJoinPoint joinPoint) throws Throwable {
+        long startTime = System.currentTimeMillis();
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        Map<String, Object> logData = new HashMap<>();
+        logData.put("timestamp", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
+        logData.put("request_id", UUID.randomUUID().toString());
+        logData.put("http_method", request.getMethod());
+        logData.put("uri", request.getRequestURI());
+        logData.put("api_path", request.getRequestURI().replaceAll("/\\d+", "/{id}")); // 숫자를 {id}로 대체
+        logData.put("client_ip", request.getRemoteAddr());
+
+        // API 메타정보
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        logData.put("api_name", signature.getDeclaringType().getSimpleName() + "." + signature.getName());
+
+        try {
+            Object result = joinPoint.proceed();
+            long executionTime = System.currentTimeMillis() - startTime;
+
+            logData.put("response_time_ms", executionTime);
+            logData.put("status", "success");
+            log.info(objectMapper.writeValueAsString(logData));
+            return result;
+
+        } catch (Exception e) {
+            long executionTime = System.currentTimeMillis() - startTime;
+
+            logData.put("response_time_ms", executionTime);
+            logData.put("status", "failed");
+            logData.put("error_message", e.getMessage());
+            log.error(objectMapper.writeValueAsString(logData));
+            throw e;
+        }
+    }
+
+    // 코인 구매 모니터링
     @Around("execution(* com.picktartup.coinservice.service.CoinServiceImpl.purchaseCoins(..))")
     public Object monitorCoinPurchase(ProceedingJoinPoint joinPoint) throws Throwable {
-        LocalDateTime purchaseTime = LocalDateTime.now();
-        Object[] args = joinPoint.getArgs();
-        Long userId = (Long) args[0];
-        double amount = (double) args[1];
-        double coin = (double) args[2];
-        String paymentMethod = (String) args[4];
-
-        Map<String, Object> logData = new HashMap<>();
-        logData.put("event_type", "coin_purchase");
-        logData.put("user_id", userId);
-        logData.put("cash_amount", amount);
-        logData.put("coin_amount", coin);
-        logData.put("payment_method", paymentMethod);
-        logData.put("timestamp", purchaseTime.toString());
-        logData.put("hour", purchaseTime.getHour());
-        logData.put("day_of_week", purchaseTime.getDayOfWeek().toString());
-
-        try {
-            Object result = joinPoint.proceed();
-            logData.put("status", "success");
-            log.info(objectMapper.writeValueAsString(logData));
-            return result;
-        } catch (Exception e) {
-            logData.put("status", "failed");
-            logData.put("error_message", e.getMessage());
-            log.error(objectMapper.writeValueAsString(logData));
-            throw e;
-        }
+        return monitorServiceCall(joinPoint, "coin_purchase");
     }
 
-    // 2. 코인 현금화 모니터링
+    // 코인 현금화 모니터링
     @Around("execution(* com.picktartup.coinservice.service.CoinServiceImpl.exchangeCoins(..))")
     public Object monitorCoinExchange(ProceedingJoinPoint joinPoint) throws Throwable {
-        LocalDateTime exchangeTime = LocalDateTime.now();
-        Object[] args = joinPoint.getArgs();
-        Long userId = (Long) args[0];
-        double exchangeAmount = (double) args[1];
-        String exchangeBank = (String) args[2];
+        return monitorServiceCall(joinPoint, "coin_exchange");
+    }
 
+    // 공통 서비스 호출 모니터링
+    private Object monitorServiceCall(ProceedingJoinPoint joinPoint, String eventType) throws Throwable {
+        long startTime = System.currentTimeMillis();
+        LocalDateTime eventTime = LocalDateTime.now();
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        Object[] args = joinPoint.getArgs();
         Map<String, Object> logData = new HashMap<>();
-        logData.put("event_type", "coin_exchange");
-        logData.put("user_id", userId);
-        logData.put("exchange_amount", exchangeAmount);
-        logData.put("bank", exchangeBank);
-        logData.put("timestamp", exchangeTime.toString());
-        logData.put("hour", exchangeTime.getHour());
-        logData.put("day_of_week", exchangeTime.getDayOfWeek().toString());
+        logData.put("event_type", eventType);
+        logData.put("timestamp", eventTime.format(DateTimeFormatter.ISO_DATE_TIME));
+        logData.put("hour", eventTime.getHour());
+        logData.put("day_of_week", eventTime.getDayOfWeek().toString());
+
+        // API 정보
+        logData.put("http_method", request.getMethod());
+        logData.put("uri", request.getRequestURI());
+        logData.put("api_path", request.getRequestURI().replaceAll("/\\d+", "/{id}")); // 숫자를 {id}로 대체
+        logData.put("client_ip", request.getRemoteAddr());
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        logData.put("api_name", signature.getDeclaringType().getSimpleName() + "." + signature.getName());
+        logData.put("request_id", UUID.randomUUID().toString());
 
         try {
             Object result = joinPoint.proceed();
+            long executionTime = System.currentTimeMillis() - startTime;
+
+            logData.put("response_time_ms", executionTime);
             logData.put("status", "success");
             log.info(objectMapper.writeValueAsString(logData));
             return result;
+
         } catch (Exception e) {
+            long executionTime = System.currentTimeMillis() - startTime;
+
+            logData.put("response_time_ms", executionTime);
             logData.put("status", "failed");
             logData.put("error_message", e.getMessage());
             log.error(objectMapper.writeValueAsString(logData));
             throw e;
         }
     }
-    
 }

--- a/src/main/java/com/picktartup/coinservice/aop/CoinLoggingAspect.java
+++ b/src/main/java/com/picktartup/coinservice/aop/CoinLoggingAspect.java
@@ -49,7 +49,8 @@ public class CoinLoggingAspect {
             long executionTime = System.currentTimeMillis() - startTime;
 
             logData.put("response_time_ms", executionTime);
-            logData.put("status", "success");
+            logData.put("success", true);
+            logData.put("http_status", 200); // 성공 상태 코드
             log.info(objectMapper.writeValueAsString(logData));
             return result;
 
@@ -57,7 +58,8 @@ public class CoinLoggingAspect {
             long executionTime = System.currentTimeMillis() - startTime;
 
             logData.put("response_time_ms", executionTime);
-            logData.put("status", "failed");
+            logData.put("success", false);
+            logData.put("http_status", 500); // 실패 상태 코드
             logData.put("error_message", e.getMessage());
             log.error(objectMapper.writeValueAsString(logData));
             throw e;
@@ -103,7 +105,8 @@ public class CoinLoggingAspect {
             long executionTime = System.currentTimeMillis() - startTime;
 
             logData.put("response_time_ms", executionTime);
-            logData.put("status", "success");
+            logData.put("success", true);
+            logData.put("http_status", 200); // 성공 상태 코드
             log.info(objectMapper.writeValueAsString(logData));
             return result;
 
@@ -111,7 +114,8 @@ public class CoinLoggingAspect {
             long executionTime = System.currentTimeMillis() - startTime;
 
             logData.put("response_time_ms", executionTime);
-            logData.put("status", "failed");
+            logData.put("success", false);
+            logData.put("http_status", 500); // 실패 상태 코드
             logData.put("error_message", e.getMessage());
             log.error(objectMapper.writeValueAsString(logData));
             throw e;


### PR DESCRIPTION
### 👀 관련 이슈
- #22 

### ✨ 작업한 내용
- **API 호출 로깅 구현**:
  - 모든 CoinController API 호출 시 다음과 같은 정보를 로깅하도록 구현:
    - `http_method`: 요청 HTTP 메서드(GET, POST 등).
    - `uri`: 요청된 URI.
    - `api_path`: 매핑된 API 경로(경로 변수 대체 포함).
    - `client_ip`: 클라이언트 IP 주소.
    - `response_time_ms`: 요청 처리 시간(ms).
    - `request_id`: 요청에 대한 고유 ID.
    - `status`: 성공 여부(`success` 또는 `failed`).
  - 정상 동작 및 예외 발생 시 로깅을 통해 API 호출 상황 파악.


### 🌀 PR Point
  - 현재 기록 중인 정보가 적절한지 검토 부탁드립니다.
  - 추가로 필요한 로깅 항목이 있다면 의견 부탁드립니다.

- **예외 처리**:
  - 예외 발생 시 로깅 데이터 구조가 적절한지 확인 필요합니다.
  - 추가적인 예외 유형에 대한 로깅이 필요한지 논의 필요합니다.
  
### 🍰 참고사항
- Postman 테스트 시 GET 호출만 테스트 해봤기 때문에 POST 호출로 테스트 필요합니다.

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|로그 출력 화면|![image](https://github.com/user-attachments/assets/02224a62-2bd7-49e2-8000-676409be5db4)|
