### PR TITLE
fix: 온프레미스 서비스 통신 시 SSL 인증서 적용

### DIFF
--- a/src/main/java/com/picktartup/coinservice/common/config/WebClientConfig.java
+++ b/src/main/java/com/picktartup/coinservice/common/config/WebClientConfig.java
@@ -1,32 +1,70 @@
 package com.picktartup.coinservice.common.config;
 
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+
+import javax.net.ssl.SSLException;
+import java.time.Duration;
 
 @Slf4j
 @Configuration
 public class WebClientConfig {
+
     @Value("${service.wallet.url}")
     private String walletServiceUrl;
 
     @Bean
-    public WebClient walletServiceWebClient() {
+    public WebClient walletServiceWebClient() { // Wallet WebClient 추가
+        HttpClient httpClient = HttpClient.create()
+                .secure(sslSpec -> {
+                    try {
+                        sslSpec.sslContext(
+                                SslContextBuilder.forClient()
+                                        .trustManager(InsecureTrustManagerFactory.INSTANCE) // 신뢰할 수 없는 인증서 허용
+                                        .build()
+                        );
+                    } catch (SSLException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .followRedirect(true)
+                .responseTimeout(Duration.ofSeconds(10)); // 타임아웃 설정
+
         return WebClient.builder()
                 .baseUrl(walletServiceUrl)
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .filter(ExchangeFilterFunction.ofRequestProcessor(
-                        clientRequest -> {
-                            log.debug("Request: {} {}", clientRequest.method(), clientRequest.url());
-                            return Mono.just(clientRequest);
-                        }
-                ))
+                .filter(loggingFilter()) // 로깅 필터 추가
+                .filter(errorHandler()) // 에러 핸들러 추가
+                .clientConnector(new ReactorClientHttpConnector(httpClient)) // HttpClient 연결
                 .build();
+    }
+
+    // 로깅 필터 추가 (예시)
+    private ExchangeFilterFunction loggingFilter() {
+        return ExchangeFilterFunction.ofRequestProcessor(clientRequest -> {
+            log.info("Request: {} {}", clientRequest.method(), clientRequest.url());
+            return Mono.just(clientRequest);
+        });
+    }
+
+    // 에러 핸들러 추가 (예시)
+    private ExchangeFilterFunction errorHandler() {
+        return ExchangeFilterFunction.ofResponseProcessor(clientResponse -> {
+            if (clientResponse.statusCode().is4xxClientError() || clientResponse.statusCode().is5xxServerError()) {
+                log.error("Error response: {}", clientResponse.statusCode());
+            }
+            return Mono.just(clientResponse);
+        });
     }
 }


### PR DESCRIPTION
### ✨ 작업한 내용
**SSL 설정**
- HttpClient를 생성할 때 secure 메서드를 사용하여 SSLContext를 설정합니다.
- 신뢰할 수 없는 인증서(InsecureTrustManagerFactory.INSTANCE)를 허용합니다.

```
HttpClient httpClient = HttpClient.create()
       .secure(sslSpec -> {
           try {
               sslSpec.sslContext(
                       SslContextBuilder.forClient()
                               .trustManager(InsecureTrustManagerFactory.INSTANCE) // 신뢰할 수 없는 인증서 허용
                               .build()
               );
           } catch (SSLException e) {
               throw new RuntimeException(e);
           }
       })
```
이 설정은 외부 API와의 보안 연결(SSL)을 설정할 때 필요합니다. 만약 API가 인증서 검증을 하지 않거나 유효하지 않은 인증서를 사용할 때 유용합니다.
